### PR TITLE
🔧add `init` script for mysql container to run tests without db permission errors

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/mysql/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/mysql/Dockerfile
@@ -4,3 +4,7 @@ COPY ./compose/production/mysql/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*
 RUN mv /usr/local/bin/maintenance/* /usr/local/bin \
     && rmdir /usr/local/bin/maintenance
+
+COPY ./compose/production/mysql/init.sh /docker-entrypoint-initdb.d
+RUN sed -i 's/\r$//g' /docker-entrypoint-initdb.d/init.sh
+RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/init.sh

--- a/{{cookiecutter.project_slug}}/compose/production/mysql/init.sh
+++ b/{{cookiecutter.project_slug}}/compose/production/mysql/init.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+
+initialize() {
+    {
+        mysql_note "Giving user ${MYSQL_USER} access to schema test_${MYSQL_DATABASE}"
+        docker_process_sql --database=mysql <<<"GRANT ALL ON \`test_${MYSQL_DATABASE//_/\\_}\`.* TO '$MYSQL_USER'@'%' ;"
+
+        # exporting dummy MYSQL_ONETIME_PASSWORD to avoid -> MYSQL_ONETIME_PASSWORD: unbound variable
+        export DUMMY_ONETIME_PASSWORD="$MYSQL_ROOT_PASSWORD"
+    } || {
+        exit 1
+    }
+}
+
+docker_process_sql() {
+	if [ -n "$MYSQL_DATABASE" ]; then
+		set -- --database="$MYSQL_DATABASE" "$@"
+	fi
+
+	mysql --protocol=socket -uroot --password="${MYSQL_ROOT_PASSWORD}" -hlocalhost --socket="${SOCKET}" --comments "$@"
+}
+
+# logging functions
+mysql_log() {
+	local type="$1"; shift
+	# accept argument string or stdin
+	local text="$*"; if [ "$#" -eq 0 ]; then text="$(cat)"; fi
+	local dt; dt="$(date --rfc-3339=seconds)"
+	printf '%s [%s] [Entrypoint]: %s\n' "$dt" "$type" "$text"
+}
+
+mysql_note() {
+	mysql_log Note "$@"
+}
+
+until (initialize); do
+    >&2 echo 'Waiting for MYSQL to execute init'
+    sleep 1
+done


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

Fixed error when running `pytest` in `Docker` containers.

## Description

When pytest runs, a new test database is created for testing purposes with the name `test_{original_db_name}`. When MySQL container builds, `MYSQL_USER` does not have permissions to access this test database which causes errors. I have added an `init` script that will give appropriate permissions to `MYSQL_USER` to access the test database. All the `.sh` formatting are inline with the official MySQL image.

<!-- What's it you're proposing? -->

Checklist:

- [ x ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ x ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
🥙

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
#7 
